### PR TITLE
fix: Update action descriptions referring to SQ for CQ

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -4,7 +4,7 @@ export function getActionDefinitions(self) {
 	return {
 		mute: {
 			name: 'Mute',
-			description: 'Mute/Unmute a specific channel on the SQ ',
+			description: 'Mute/Unmute a specific channel on the CQ ',
 			options: [
 				{
 					type: 'dropdown',
@@ -307,7 +307,7 @@ export function getActionDefinitions(self) {
 		},
 		scene: {
 			name: 'Scene Change',
-			description: 'Load a scene on the SQ mixer',
+			description: 'Load a scene on the CQ mixer',
 			options: [
 				{
 					type: 'number',
@@ -332,7 +332,7 @@ export function getActionDefinitions(self) {
 		},
 		softkey: {
 			name: 'Soft Key',
-			description: 'Press or release a Soft Key on the SQ mixer',
+			description: 'Press or release a Soft Key on the CQ mixer',
 			options: [
 				{
 					type: 'dropdown',

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -1,14 +1,13 @@
 # Allen & Heath CQ mixers
 
-1. Make sure that your mixer has a valid IP adress and is reachable from your current network environment.
+1. Make sure that your mixer has a valid IP address and is reachable from your current network environment.
 2. Put the IP of the mixer in the configuration part of the module.
-3. If the connection was successful, you can now use the available actions, feedbacks and variables. 
-
-
+3. If the connection was successful, you can now use the available actions, feedbacks and variables.
 
 ## Actions
 
 ### 1. Mute/Unmute Channels
+
 - **Description**: Mute, unmute, or toggle the mute state of a specific channel.
 - **Options**:
   - Channel selection.
@@ -16,6 +15,7 @@
 - **Action**: Sends a MIDI message to mute/unmute a channel.
 
 ### 2. Pan/Balance [Absolute]
+
 - **Description**: Set the pan/balance of individual channels to a specific target.
 - **Options**:
   - Channel selection.
@@ -24,6 +24,7 @@
 - **Action**: Sends a MIDI message to set the pan position.
 
 ### 3. Pan/Balance [Relative]
+
 - **Description**: Adjust pan/balance incrementally.
 - **Options**:
   - Channel selection.
@@ -32,6 +33,7 @@
 - **Action**: Sends a MIDI message to adjust pan based on direction.
 
 ### 4. Volume Control - Inputs to Outputs/FX [Absolute]
+
 - **Description**: Set an absolute dB value for Inputs or FX channels.
 - **Options**:
   - Channel selection.
@@ -40,6 +42,7 @@
 - **Action**: Sends a MIDI message to set volume levels.
 
 ### 5. Volume Control - Inputs to Outputs/FX [Relative]
+
 - **Description**: Increment or decrement volume by 1 dB.
 - **Options**:
   - Channel selection.
@@ -48,6 +51,7 @@
 - **Action**: Sends a MIDI message for volume adjustment.
 
 ### 6. Volume Control - Outputs, FX, DCAs [Absolute]
+
 - **Description**: Set the volume for outputs, FX unit inputs, or DCAs.
 - **Options**:
   - Channel selection.
@@ -55,6 +59,7 @@
 - **Action**: Sends a MIDI message to adjust volume.
 
 ### 7. Volume Control - Outputs, FX, DCAs [Relative]
+
 - **Description**: Adjust output or FX/DCAs volume incrementally.
 - **Options**:
   - Channel selection.
@@ -62,37 +67,38 @@
 - **Action**: Sends a MIDI message to adjust volume.
 
 ### 8. Scene Change
+
 - **Description**: Load a scene on the CQ mixer.
 - **Options**:
   - Scene number (1-100).
 - **Action**: Sends a MIDI message to load the selected scene and updates the active scene feedback.
 
 ### 9. Soft Key Control
+
 - **Description**: Press or release a soft key on the CQ mixer.
 - **Options**:
   - Soft Key selection: `Soft Key 1`, `Soft Key 2`, `Soft Key 3`.
   - Action: `Press`, `Release`.
 - **Action**: Sends a MIDI message to simulate a key press or release.
 
-
 ## Feedback
 
 ### 1. Mute Status
+
 - **Description**: Monitors if a specific channel is muted.
 - **Options**:
   - Channel selection.
 - **Feedback**: Returns a boolean indicating the current mute state of the channel.
 
 ### 2. Scene Active
+
 - **Description**: Checks if a specific scene is currently active.
 - **Options**:
   - Scene number (1-100).
 - **Feedback**: Returns a boolean indicating if the specified scene is active.
 
-
-
 ## Known Issues
 
 1. When the module is sending out "GET" messages for the current mute state of Mute Groups or DCAs, the console always returns 'off' (fix by Allen & Heath needed, not a Companion related issue)
 2. Mute toggle is not working for DCAs and Mute Groups (fix by Allen & Heath needed, not a Companion related issue)
-3. The console has no function for lettig the Companion module get the currently active scene. Therefore after a scene is loaded from the Companion action, the module just assumes that the scene was loaded successfully (fix by Allen & Heath needed, not a Companion related issue).
+3. The console has no function for letting the Companion module get the currently active scene. Therefore after a scene is loaded from the Companion action, the module just assumes that the scene was loaded successfully (fix by Allen & Heath needed, not a Companion related issue).

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -62,13 +62,13 @@
 - **Action**: Sends a MIDI message to adjust volume.
 
 ### 8. Scene Change
-- **Description**: Load a scene on the SQ mixer.
+- **Description**: Load a scene on the CQ mixer.
 - **Options**:
   - Scene number (1-100).
 - **Action**: Sends a MIDI message to load the selected scene and updates the active scene feedback.
 
 ### 9. Soft Key Control
-- **Description**: Press or release a soft key on the SQ mixer.
+- **Description**: Press or release a soft key on the CQ mixer.
 - **Options**:
   - Soft Key selection: `Soft Key 1`, `Soft Key 2`, `Soft Key 3`.
   - Action: `Press`, `Release`.

--- a/config.js
+++ b/config.js
@@ -5,7 +5,7 @@ export const ConfigFields = [
 		type: 'textinput',
 		id: 'host',
 		label: 'Mixer IP',
-		tooltip: 'Enter the IP adress of the CQ mixer and make sure it is reachable from your network.',
+		tooltip: 'Enter the IP address of the CQ mixer and make sure it is reachable from your network.',
 		width: 8,
 		regex: Regex.IP,
 	},


### PR DESCRIPTION
This module was originally based on the module for SQ and has some references to SQ leftover.

This PR should resolve those instances as well as some other small spelling/formatting errors.