### PR TITLE
fix: Correct "Allen & Heath" naming for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # companion-module-allenheath-cq
 
-This module allows you to control all the available parameters on Allen&Heath CQ mixers. Please note that the module currently supports everything which is documented in the official MIDI protocol document provided by Allen&Heath.
+This module allows you to control all the available parameters on Allen & Heath CQ mixers. Please note that the module currently supports everything which is documented in the official MIDI protocol document provided by Allen & Heath.

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -2,7 +2,7 @@
 	"id": "allenheath-cq",
 	"name": "allenheath-cq",
 	"shortname": "allenheath-cq",
-	"description": "Control Allen&Heath CQ mixers",
+	"description": "Control Allen & Heath CQ mixers",
 	"version": "1.0.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-allenheath-cq.git",
@@ -20,7 +20,7 @@
 		"apiVersion": "0.0.0",
 		"entrypoint": "../index.js"
 	},
-	"manufacturer": "Allen Heath",
+	"manufacturer": "Allen & Heath",
 	"products": ["CQ-12T", "CQ-18T", "CQ-20B"],
 	"keywords": []
 }


### PR DESCRIPTION
This PR fixes mismatched references to the name "Allen & Heath".