### PR TITLE
fix: Stricter dependency version matching

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "allenheath-cq",
 	"shortname": "allenheath-cq",
 	"description": "Control Allen & Heath CQ mixers",
-	"version": "1.0.0",
+	"version": "0.0.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-allenheath-cq.git",
 	"bugs": "https://github.com/bitfocus/companion-module-allenheath-cq/issues",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"@companion-module/base": "^1.11.0"
+		"@companion-module/base": "~1.11.0"
 	},
 	"devDependencies": {
-		"@companion-module/tools": "^2.1.0"
-	}
+		"@companion-module/tools": "~2.1.0"
+	},
+	"prettier": "@companion-module/tools/.prettierrc.json"
 }


### PR DESCRIPTION
Currently, package manager will grab base 1.13 which is not compatible with current stable release, resulting in below error:

```
Instance/ModuleHost: Module Api version is too new/old: "3C3objXGRA1Z7BqI4W0v9" 1.13.2
```

This prevents the module from being released for n-1 stable Companion version so I have made the version matching stricter to be fixed to 1.11.x.